### PR TITLE
Gebruiker feedback geven over like-status per tweet

### DIFF
--- a/src/app/api/like/route.ts
+++ b/src/app/api/like/route.ts
@@ -63,3 +63,45 @@ export async function POST(req: Request) {
     });
   }
 }
+
+export async function GET(req: Request) {
+  try {
+    const tweetID = await req.json();
+
+    const session = await auth
+      .handleRequest({
+        request: null,
+        cookies,
+      })
+      .validate();
+
+    if (!session) {
+      return NextResponse.json(null, {
+        status: 401,
+      });
+    }
+
+    const like = await prisma.like.findUnique({
+      where: {
+        userId_tweetId: {
+          tweetId: tweetID,
+          userId: session.user.userId,
+        },
+      },
+    });
+
+    if (like) {
+      return NextResponse.json(true, {
+        status: 200,
+      });
+    } else {
+      return NextResponse.json(false, {
+        status: 200,
+      });
+    }
+  } catch (e) {
+    return NextResponse.json(null, {
+      status: 500,
+    });
+  }
+}

--- a/src/app/api/like/route.ts
+++ b/src/app/api/like/route.ts
@@ -1,4 +1,4 @@
-import { auth } from "@/server/lucia";
+import { auth, getPageSession } from "@/server/lucia";
 import { prisma } from "@/server/prisma";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
@@ -7,18 +7,7 @@ export async function POST(req: Request) {
   try {
     const tweetID = await req.json();
 
-    const session = await auth
-      .handleRequest({
-        request: null,
-        cookies,
-      })
-      .validate();
-
-    if (!session) {
-      return NextResponse.json(null, {
-        status: 401,
-      });
-    }
+    const session = await getPageSession();
 
     const like = await prisma.like.findUnique({
       where: {

--- a/src/app/api/tweet/new/route.ts
+++ b/src/app/api/tweet/new/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
     })
     .validate();
 
-  const tweet = await prisma.tweet.create({
+  await prisma.tweet.create({
     data: {
       content: data.content,
       user: {

--- a/src/app/api/tweet/new/route.ts
+++ b/src/app/api/tweet/new/route.ts
@@ -1,17 +1,11 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/server/prisma";
-import { auth } from "@/server/lucia";
-import { cookies } from "next/headers";
+import { getPageSession } from "@/server/lucia";
 
 export async function POST(req: Request) {
   const data = await req.json();
 
-  const session = await auth
-    .handleRequest({
-      request: null,
-      cookies,
-    })
-    .validate();
+  const session = await getPageSession();
 
   await prisma.tweet.create({
     data: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,14 @@
 import { Button } from "@/components/General";
 import { NewTweet } from "@/components/NewTweet";
 import { Tweets } from "@/components/Ui";
-import { auth } from "@/server/lucia";
+import { auth, getPageSession } from "@/server/lucia";
 import { prisma } from "@/server/prisma";
 import { cookies } from "next/headers";
 import Link from "next/link";
 
 export default async function Home() {
+  const session = await getPageSession();
+
   const tweets = await prisma.tweet.findMany({
     take: 10,
     orderBy: { createdAt: "desc" },
@@ -17,15 +19,13 @@ export default async function Home() {
           likes: true,
         },
       },
+      likes: {
+        where: {
+          userId: session?.user.userId,
+        },
+      },
     },
   });
-
-  const session = await auth
-    .handleRequest({
-      request: null,
-      cookies,
-    })
-    .validate();
 
   return (
     <div className="container mx-auto flex min-h-screen">

--- a/src/components/General/TweetToolBar.tsx
+++ b/src/components/General/TweetToolBar.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 
 interface TweetToolBarProps {
   likes: number;
+  isLiked: boolean;
   id: Tweet["id"];
 }
 
@@ -13,7 +14,11 @@ interface updateLikesProps {
   id: Tweet["id"];
 }
 
-export default function TweetToolBar({ id, likes }: TweetToolBarProps) {
+export default function TweetToolBar({
+  id,
+  likes,
+  isLiked,
+}: TweetToolBarProps) {
   const router = useRouter();
 
   const updateLikes = async ({ id }: updateLikesProps) => {
@@ -39,6 +44,7 @@ export default function TweetToolBar({ id, likes }: TweetToolBarProps) {
         bgColor={"group-hover:bg-yellow-200"}
         meta={likes}
         onClick={() => updateLikes({ id })}
+        status={isLiked}
       ></TweetToolBarItem>
       <TweetToolBarItem
         icon={<CommentIcon />}
@@ -55,7 +61,7 @@ interface TweetToolBarItemProps {
   icon: JSX.Element;
   textColor: string;
   bgColor: string;
-  clicked?: boolean;
+  status?: boolean;
   onClick: () => void;
   meta: number;
 }
@@ -64,13 +70,14 @@ function TweetToolBarItem({
   icon,
   textColor,
   bgColor,
-  clicked = false,
+  status,
   onClick,
   meta,
 }: TweetToolBarItemProps) {
   let iconActive = "";
-  if (clicked) {
-    iconActive = "text-red-600";
+
+  if (status) {
+    iconActive = "text-red-500";
   }
 
   return (

--- a/src/components/Ui/Tweets.tsx
+++ b/src/components/Ui/Tweets.tsx
@@ -1,4 +1,4 @@
-import type { Tweet, User } from "@prisma/client";
+import type { Like, Tweet, User } from "@prisma/client";
 import { TweetToolBar } from "../General";
 
 interface TweetWithUser extends Tweet {
@@ -6,6 +6,7 @@ interface TweetWithUser extends Tweet {
   _count: {
     likes: number;
   };
+  likes: Array<Like>;
 }
 
 interface TweetsProps {
@@ -19,7 +20,11 @@ export default async function Tweets({ tweets }: TweetsProps) {
         <li key={t.id} className="border px-4 py-6 text-white">
           <small>@{t.user.username}</small>
           <p>{t.content}</p>
-          <TweetToolBar id={t.id} likes={t._count.likes}></TweetToolBar>
+          <TweetToolBar
+            id={t.id}
+            isLiked={Boolean(t.likes.length)}
+            likes={t._count.likes}
+          ></TweetToolBar>
         </li>
       ))}
     </ul>

--- a/src/server/lucia.ts
+++ b/src/server/lucia.ts
@@ -2,6 +2,8 @@ import { lucia } from "lucia";
 import { prisma } from "@lucia-auth/adapter-prisma";
 import { prisma as db } from "./prisma";
 import { nextjs } from "lucia/middleware";
+import { cache } from "react";
+import { cookies } from "next/headers";
 
 // default values
 export const auth = lucia({
@@ -24,3 +26,11 @@ export const auth = lucia({
 });
 
 export type Auth = typeof auth;
+
+export const getPageSession = cache(() => {
+  const authRequest = auth.handleRequest({
+    request: null,
+    cookies,
+  });
+  return authRequest.validate();
+});


### PR DESCRIPTION
Likes: worden per tweet opgehaald waar een UserID gelijk is aan session.user.id.

Op het moment wordt de like als geheel object meegestuurd. 

Kan ook als getal, maar dan zou er nog een aparte DB query voor gemaakt moeten worden.

Is het beter om een klein beetje extra data mee te sturen dan om een 2e query uit te voeren?