### PR TITLE
Send user to sign-up when 401 is returned from like

### DIFF
--- a/src/components/General/TweetToolBar.tsx
+++ b/src/components/General/TweetToolBar.tsx
@@ -18,13 +18,16 @@ export default function TweetToolBar({ id, likes }: TweetToolBarProps) {
 
   const updateLikes = async ({ id }: updateLikesProps) => {
     try {
-      await fetch("/api/like", {
+      const response = await fetch("/api/like", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         body: JSON.stringify(id),
       });
+      if (response.status == 401) {
+        router.push("/sign-up");
+      }
       router.refresh();
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
Ben er niet zo heel bekend mee. Maar volgensmij is zoiets als dit (redirecten bij 401) iets wat ik beter met middleware kan afvangen toch?

Dat elke 401 vanuit de middleware wordt doorgestuurd naar de sign-up page.

Maakt voor nu niet veel uit omdat het maar op 1 plek gebeurd, maar als het project groeit. Is dat dan een betere optie?
